### PR TITLE
openSUSE support and improve search_grub

### DIFF
--- a/custom/grub.cfg
+++ b/custom/grub.cfg
@@ -32,11 +32,11 @@ set pager=1
 keymap usqwerty
 function try_user_config {
 	set root="${1}"
-	for dir in boot grub grub2 boot/grub boot/grub2 @/boot/grub @/boot/grub2; do
-		for name in '' osboot_ autoboot_ libreboot_ coreboot_; do
-			if [ -f /"${dir}"/"${name}"grub.cfg ]; then
+	for dir in /boot /grub* /boot/grub* /@/boot/grub* /@/grub*; do
+		for cfg in ${dir}/*boot_grub.cfg ${dir}/grub.cfg; do
+			if [ -f "${cfg}" ]; then
 				unset superusers
-				configfile /"${dir}"/"${name}"grub.cfg
+				configfile ${cfg}
 			fi
 		done
 	done
@@ -44,13 +44,12 @@ function try_user_config {
 function search_grub {
 	echo -n "Attempting to load grub.cfg from: "
 	# FIXME: Does this work on all boards?
-	
-	# Tries all partitions in all disks in reverse order
+	# Tries all partitions in all disks in descending order
 	for diskpart in (${1}*,*); do
 		try_user_config "${diskpart}"
 	done
 	
-	# Tries all raw devices in reverse order (9, 8, 7, ...)
+	# Tries all raw devices in descending order (9, 8, 7, ...)
 	for disk in (${1}*); do
 		try_user_config "${disk}"
 	done

--- a/custom/grub.cfg
+++ b/custom/grub.cfg
@@ -44,12 +44,13 @@ function try_user_config {
 function search_grub {
 	echo -n "Attempting to load grub.cfg from: "
 	# FIXME: Does this work on all boards?
-	# Tries all partitions in all disks in descending order
+	
+	# Tries all partitions in all disks in the same order listed by the "ls" command 
 	for diskpart in (${1}*,*); do
 		try_user_config "${diskpart}"
 	done
 	
-	# Tries all raw devices in descending order (9, 8, 7, ...)
+	# Tries all raw devices
 	for disk in (${1}*); do
 		try_user_config "${disk}"
 	done

--- a/custom/grub.cfg
+++ b/custom/grub.cfg
@@ -32,7 +32,7 @@ set pager=1
 keymap usqwerty
 function try_user_config {
 	set root="${1}"
-	for dir in boot grub grub2 boot/grub boot/grub2 @/boot/grub; do
+	for dir in boot grub grub2 boot/grub boot/grub2 @/boot/grub @/boot/grub2; do
 		for name in '' osboot_ autoboot_ libreboot_ coreboot_; do
 			if [ -f /"${dir}"/"${name}"grub.cfg ]; then
 				unset superusers
@@ -43,19 +43,16 @@ function try_user_config {
 }
 function search_grub {
 	echo -n "Attempting to load grub.cfg from: "
-	# TODO : Find a better way to detect how many disks
-	#	   : are on the computer instead of hardcoding.
 	# FIXME: Does this work on all boards?
-	for i in 0 1 2 3 4 5 6 7 8 9 10 11; do
-		# TODO : Find a better way to detect how many partitions
-		#      : are on the disk instead of hardcoding.
-		for part in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
-			# MBR/GPT partitions
-			try_user_config "(${1}${i},${part})"
-		done
-		# raw devices
-		try_user_config "(${1}${i})"
-		echo # Insert newline
+	
+	# Tries all partitions in all disks in reverse order
+	for diskpart in (${1}*,*); do
+		try_user_config "${diskpart}"
+	done
+	
+	# Tries all raw devices in reverse order (9, 8, 7, ...)
+	for disk in (${1}*); do
+		try_user_config "${disk}"
 	done
 }
 


### PR DESCRIPTION
**try_user_config**
Added support for openSUSE distributions that store grub in `@/boot/grub2` by default. 
Added leading slash to paths to prevent them being recognized as strings (/boot vs boot).
Added wildcards to catch grub vs grub2 and *boot_grub.cfg files. -- *May not want to do this to prevent unwanted files or directories from being searched?*

**search_grub**
Added wildcards to disk and partition iteration to remove hardcoded integer ID's.
Confirmed it will handle ID's 10+ (ahci10, ahci11, ...), but does so in descending order for the first ten digits? (9, 8, 7, ..., 1, 0, 10. 11, 12, ...).