### PR TITLE
Improve grub.cfg

### DIFF
--- a/custom/grub.cfg
+++ b/custom/grub.cfg
@@ -10,7 +10,6 @@ insmod usb
 insmod usbms
 insmod regexp
 
-# Serial and keyboard configuration, very important.
 terminal_input --append at_keyboard
 terminal_input --append usb_keyboard
 terminal_output --append cbmemc
@@ -18,42 +17,51 @@ terminal_output --append cbmemc
 gfxpayload=keep
 terminal_output --append gfxterm
 
-insmod png
-loadfont (cbfsdisk)/font.pf2
-set theme=(cbfsdisk)/theme.txt
+if [ -f (cbfsdisk)/font.pf2 ]; then
+	loadfont (cbfsdisk)/font.pf2
+fi
+if [ -f (cbfsdisk)/theme.txt ]; then
+	set theme=(cbfsdisk)/theme.txt
+fi
+if [ -f (cbfsdisk)/background.png ]; then
+	insmod png
+	background_image (cbfsdisk)/background.png
+elif [ -f (cbfsdisk)/background.jpg ]; then
+	insmod jpeg
+	background_image (cbfsdisk)/background.jpg
+fi
 
-# Default to first option, automatically boot after 1 second
 set default="0"
 set timeout=10
-
-# This is useful when using 'cat' on long files on GRUB terminal
 set pager=1
+set grub_scan_disk="ahci"
 
 keymap usqwerty
 function try_user_config {
 	set root="${1}"
-	for dir in boot grub grub2 boot/grub boot/grub2 @/boot/grub grub* boot/grub* @/boot/grub* @/grub; do
-		for name in '' osboot_ autoboot_ libreboot_ coreboot_; do
-			if [ -f /"${dir}"/"${name}"grub.cfg ]; then
-				unset superusers
-				configfile /"${dir}"/"${name}"grub.cfg
-			fi
-		done
+	for dir in /boot /grub* /@ /@boot /@grub*; do
+		if [ -d ${dir} ]; then
+			for subdir in ${dir} ${dir}/boot ${dir}/boot/grub* ${dir}/grub*; do
+				if [ -d ${subdir} ]; then
+					for name in '' osboot_ autoboot_ libreboot_ coreboot_; do
+						if [ -f ${subdir}/${name}grub.cfg ]; then
+							unset superusers
+							configfile ${subdir}/${name}grub.cfg
+						fi
+					done
+				fi
+			done
+		fi
 	done
 }
 function search_grub {
 	echo -n "Attempting to load grub.cfg from: "
-	for diskpart in (${1}*,*); do
-		echo "${diskpart}"
-		try_user_config "${diskpart}"
-	done
-
-	# Tries all raw devices
+	# Tries all partitions then all raw devices
 	for disk in (${1}*); do
+		echo "${disk}"
 		try_user_config "${disk}"
 	done
 }
-
 function try_isolinux_config {
 	set root="${1}"
 	for dir in '' /boot; do
@@ -65,180 +73,139 @@ function try_isolinux_config {
 	done
 }
 function search_isolinux {
-	unset ddev
-	if [ (${1}?) != "(${1}?)" ]; then
-		ddev=(${1}*) # Both raw and partitioned devices.
-		echo -n "Attempting to parse isolinux menu from: "
+	echo
+	echo "Attempting to parse isolinux/syslinux config from '${1}' devices"
+	if [ -d (${1}*) ]; then
+		for part in (${1}*); do
+			try_isolinux_config ${part}
+		done
 	fi
-	for i in ${ddev}; do
-		echo -n "${i} "
-		try_isolinux_config "${i}"
-	done
 	echo # Insert newline
 }
-menuentry 'Load Disk Grub [o]' --hotkey='o' {
-# GRUB2 handles (almost) every possible disk setup, but only the location of
-# /boot is actually important since GRUB2 only loads the user's config.
+menuentry 'Load Operating System          [o]' --hotkey='o' {
 
-# LVM, RAID, filesystems and encryption on both raw devices and partitions in
-# all various combinations need to be supported. Since full disk encryption is
-# possible with GRUB2 as payload and probably even used by most users, this
-# configuration tries to load the operating system in the following way:
-
-# 1. Look for user configuration on unencrypted devices first to avoid
-# unnecessary decryption routines in the following order:
-
-#	1) raw devices and MBR/GPT partitions
-#	2) LVM and RAID which might be used accross multiple devices
-	unset lvmvol
-	for vol in bootvol rootvol; do
-		if [ (lvm\/?atrix-${vol}) != "(lvm/?atrix-${vol})" ]; then # Sketchy check, hardcoded string to be dropped in future
-			lvmvol="${lvmvol} (lvm/matrix-${vol})"
-		fi
-	done
-	unset raidvol
-	if [ (md/?) != "(md/?)" ] ; then
-		raidvol=(md/?)
+	if [ "${grub_scan_disk}" != "ata" ]; then
+		search_grub ahci
 	fi
-	for vol in ${lvmvol} ${raidvol} ; do
-		try_user_config "${vol}"
-	done
-# 2. In case no configuration could be found, try decrypting devices. Look
-# on raw crypto devices as well as inside LVM volumes this time.
+	if [ "${grub_scan_disk}" != "ahci" ]; then
+		search_grub ata
+	fi
 
-#	The user will be prompted for a passphrase if a LUKS header was found.
-# Encrypted disks and partitions
-#TODO: This needs to be adjusted on each device to exclude ODD
-#TODO: Usually ATA is for odd if both exist!
-#TODO: Unset variables before use!
-#TODO: Pick better variable name scheme than ${ddev}, or find way to make it local
+	# TODO: add more strings, based on what distros set up when
+	# the user select auto-partitioning on those installers
+	if [ -d (lvm/matrix-?ootvol) ]; then
+		for vol in (lvm/matrix-bootvol) (lvm/matrix-rootvol); do
+			try_user_config "${vol}"
+		done
+	fi
+	
+	# raid volumes, only 0-9
+	if [ -d (md/?) ]; then
+		for raidvol in (md/?); do
+			try_user_config (md/?)
+		done
+	fi
+	
 	unset ahcidev
 	unset atadev
-	if [ (ahci?) != "(ahci?)" ]; then
-		ahcilist=(ahci*)
-		for part in ${ahcilist}; do
-				ahcidev="$part $ahcidev"
+	# get all ahci/ata raw disks and partitions
+	if [ -d (${grub_scan_disk}*) ]; then
+		for part in (${grub_scan_disk}*); do
+			diskdev="$part $diskdev"
 		done
 	fi
-	if [ (ata?) != "(ata?)" ]; then
-		atalist=(ata*)
-		for part in ${atalist}; do
-				atadev="$part $atadev"
-		done
-	fi
+
 	set pager=0
-	echo -n "Attempting to cryptomount: "
-	for dev in ${ahcidev} ${atadev} ${lvmvol} ${raidvol}; do
-		echo -n "${dev} "
+	echo -n "Attempting to unlock encrypted volumes"
+	for dev in ${diskdev} ${lvmvol} ${raidvol}; do
 		if cryptomount "${dev}" ; then break ; fi
 	done
 	set pager=1
-	echo # Insert newline
+	echo
 
-# Rescan lvm volumes, should probably use test at this point
-	unset lvmvol
-	for vol in bootvol rootvol; do
-		if [ (lvm\/?atrix-${vol}) != "(lvm/?atrix-${vol})" ]; then # Sketchy check, hardcoded string to be dropped in future
-			lvmvol="${lvmvol} (lvm/matrix-${vol})"
-		fi
-	done
-
-#	3) LVM inside LUKS containers
+	# after cryptomount, lvm volumes might be available
+	# TODO: detect crypt volumes and provide the user a list of options to decrypt 
+	# first. then, provide a list of all detected grub.cfg to choose from
 	for vol in ${lvmvol}; do
 		try_user_config "${vol}"
 	done
 
-#	4) encrypted devices/partitions
 	search_grub crypto
-	search_grub ahci
-	search_grub ata
 
-# TODO: generalize last resorts
-# Use first connected device? not just sata port 1
-
-	# Last resort, if all else fails
-	set root=ahci0,1
-	for p in / /boot/; do
-		if [ -f "${p}vmlinuz" ]; then
-			linux ${p}vmlinuz root=/dev/sda1 rw
-			if [ -f "${p}initrd.img" ]; then
-				initrd ${p}initrd.img
+	if [ "${grub_scan_disk}" != "ata" ]; then
+		# Last resort, if all else fails
+		set root=ahci0,1
+		for p in / /boot/; do
+			if [ -f "${p}vmlinuz" ]; then
+				linux ${p}vmlinuz root=/dev/sda1 rw
+				if [ -f "${p}initrd.img" ]; then
+					initrd ${p}initrd.img
+				fi
 			fi
-		fi
-	done
+		done
+	fi
 
-	# Last resort (for setups that use IDE instead of SATA)
-	set root=ata0,1
-	for p in / /boot/; do
-		if [ -f "${p}vmlinuz" ]; then
-			linux ${p}vmlinuz root=/dev/sda1 rw
-			if [ -f "${p}initrd.img" ]; then
-				initrd ${p}initrd.img
+	if [ "${grub_scan_disk}" != "ahci" ]; then
+		# Last resort (for setups that use IDE instead of SATA)
+		set root=ata0,1
+		for p in / /boot/; do
+			if [ -f "${p}vmlinuz" ]; then
+				linux ${p}vmlinuz root=/dev/sda1 rw
+				if [ -f "${p}initrd.img" ]; then
+					initrd ${p}initrd.img
+				fi
 			fi
-		fi
-	done
+		done
+	fi
 
 	true # Prevent pager requiring to accept each line instead of whole screen
 }
-
-menuentry 'Search ISOLINUX menu (AHCI) [a]' --hotkey='a' {
+menuentry 'Search ISOLINUX menu (AHCI)    [a]' --hotkey='a' {
 	search_isolinux ahci
 }
-menuentry 'Search ISOLINUX menu (USB) [u]' --hotkey='u' {
+menuentry 'Search ISOLINUX menu (USB)     [u]' --hotkey='u' {
 	search_isolinux usb
 }
-menuentry 'Search ISOLINUX menu (CD/DVD) [d]' --hotkey='d' {
-	insmod ata
-	unset ahcidev
-	unset atadev
-	if [ (ata?) != "(ata?)" ]; then
-		atadev=(ata?) # Only full drives not partitions
-	fi
-	if [ (ahci?) != "(ahci?)" ]; then
-		ahcidev=(ahci1) # TODO: hardcoded!!!
-	fi
-	echo -n "Attempting to parse isolinux menu from: "
-	for dev in ${atadev} ${ahcidev}; do
-		echo -n "${dev} "
-		try_isolinux_config "${dev}"
-	done
-	echo # Insert newline
+menuentry 'Search ISOLINUX menu (ATA/IDE) [d]' --hotkey='d' {
+	search_isolinux ata
 }
-menuentry 'Load Test Configuration [t]' --hotkey='t' {
+menuentry 'Load test configuration        [t]' --hotkey='t' {
 	set root='(cbfsdisk)'
 	if [ -f /grubtest.cfg ]; then
 		configfile /grubtest.cfg
 	fi
 }
-menuentry 'Search External Media [s]' --hotkey='s' {
+menuentry 'Search for external USB        [s]' --hotkey='s' {
 	search_grub usb
 }
-menuentry 'Show Build Details [x]' --hotkey='x' {
-	cat (cbfsdisk)/DETAILS
-	echo # insert newline
-	sleep 2
-}
 if [ -f (cbfsdisk)/seabios.elf ]; then
-menuentry 'Load SeaBIOS [b]' --hotkey='b' {
+menuentry 'Load SeaBIOS (payload)         [b]' --hotkey='b' {
 	set root='cbfsdisk'
 	chainloader /seabios.elf
 }
 fi
 if [ -f (cbfsdisk)/img/grub2 ]; then
-menuentry 'Return to SeaBIOS [b]' --hotkey='b' {
+menuentry 'Return to SeaBIOS              [b]' --hotkey='b' {
 	set root='cbfsdisk'
 	chainloader /fallback/payload
 }
 fi
-menuentry 'Poweroff  [p]' --hotkey='p' {
-	halt
+if [ -f (cbfsdisk)/DETAILS ]; then
+menuentry 'Show Build Details             [x]' --hotkey='x' {
+	cat (cbfsdisk)/DETAILS
+	echo # insert newline
+	sleep 2
 }
-menuentry 'Reboot  [r]' --hotkey='r' {
-	reboot
-}
+fi
 if [ -f (cbfsdisk)/img/memtest ]; then
-menuentry 'Load MemTest86+  [m]' --hotkey='m' {
+menuentry 'Load MemTest86+                [m]' --hotkey='m' {
 	set root='cbfsdisk'
 	chainloader /img/memtest
 }
 fi
+menuentry 'Poweroff                       [p]' --hotkey='p' {
+	halt
+}
+menuentry 'Reboot                         [r]' --hotkey='r' {
+	reboot
+}

--- a/custom/grub.cfg
+++ b/custom/grub.cfg
@@ -1,3 +1,6 @@
+#hide kernel & initrd flash download progress indicators
+rmmod progress
+
 set prefix=(memdisk)/boot/grub
 
 insmod at_keyboard

--- a/patch.sh
+++ b/patch.sh
@@ -10,6 +10,7 @@ done
 }
 
 dir=$PWD
+mkdir -p $dir/bin
 type=$1
 cp roms/* "$type"
 cd "$type"
@@ -17,6 +18,7 @@ cd "$type"
 Cbchange background.*
 Cbchange grub.cfg
 Cbchange theme.txt
+Cbchange DETAILS
 Cbchange font.pf2
 
 if [ "$type" = "custom" ] ; then


### PR DESCRIPTION
I rebased with the latest `grub.cfg` I got from lbmk. I then overlaid my original fixes before making changes.

- The try_user_config works better with btrfs and with more boot directory configurations.
- The redundant partition check in search_grub has been removed as the raw disk check already checks partitions anyways (and it checks all partitions before checking any raw disks anyways).
- The raid and lvm volume check section has been simplified.

Let me know what you think. Thanks.


I know Leah has/had concerns about using too much enumeration due to grub's enumeration being very slow, but I haven't run into this issue on my x200. Disk decryption typically takes far longer than searching for grub, and my grub file loads almost instantly on an unencrypted installation. Maybe this issue would be noticeable with dozens of partitions.

This has me thinking about how the boot sequence can be further optimized. I've done some testing, and I think it should be doable to dynamically create a submenu with a list of available `grub.cfg` files as well as the option to decrypt specific disks/partitions. This way, a user won't have to sit through a decryption attempt on a partition that they want to remain encrypted. 

If this sounds interesting to you, let me know, and I'll open an issue.